### PR TITLE
Corrige a versão do .NET

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 - [Docker](https://www.docker.com/)
 - [Node.js](https://nodejs.org/) `>= 18`
-- [.NET SDK](https://dotnet.microsoft.com/) `>= 8`
+- [.NET SDK](https://dotnet.microsoft.com/) `>= 10`
 
 ---
 


### PR DESCRIPTION
## [Documentação] Corrige a versão do .NET
**Ref:** N/A

---

## Problema
A versão descrita está incorreta, o projeto tem como target o .NET 10. Retrocompatibilidade das versões fica a cargo do runtime, mas para esse projeto o target é unicamente .NET 10 ou superior.

---

## Solução
Altera a descrição do arquivo

---

## Nota
Era pra esse commit já estar pronto mas como ele veio do fork e o fork morreu, to tendo q fazer de novo ;)