### PR TITLE
Adiciona regra de comentários todo

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -217,6 +217,7 @@ dotnet csharpier .
 - Métodos devem ter nomes descritivos do que fazem. `AddToDatabase` não é claro, `AddEntryToWorkspace` indica que uma nova entrada está sendo inserida e em qual tabela.
 - Interpolação de string em vez de concatenação (`$"Olá, {name}"`)
 - Comentários XML em todos os membros públicos
+- Caso necessário deixar um todo, faça da seguinte maneira: `todo (jay) fazer x coisa`
 
 #### Exemplo
 


### PR DESCRIPTION
## [Docs] Adiciona regra de comentários todo
**Ref:** N/A

---

## Problema
Comentários podem ser deixados no código como `todo`. É necessário claridade de quem deixou para não ter que ficar procurando quem deixou.

---

## Solução
Os comentários de `todo` tem que ser claros e nomeados por quem deixou.

---

## Checklist
~- [ ] Código passou no linter (`dotnet csharpier .` / `npm run format`)~
~- [ ] Testes unitários adicionados ou atualizados~
- [x] Documentação atualizada se necessário

---

Closes N/A